### PR TITLE
Support IE8 by wrapping Object.defineProperty with a try catch

### DIFF
--- a/index.js
+++ b/index.js
@@ -17,10 +17,14 @@
   };
 
   if (Object.defineProperty) {
-    Object.defineProperty(Array.prototype, 'find', {
-      value: find, configurable: true, enumerable: false, writable: true
-    });
-  } else {
+    try {
+      Object.defineProperty(Array.prototype, 'find', {
+        value: find, configurable: true, enumerable: false, writable: true
+      });
+    } catch(e) {}
+  }
+
+  if (!Array.prototype.find) {
     Array.prototype.find = find;
   }
 })(this);


### PR DESCRIPTION
"Internet Explorer 8 implemented a Object.defineProperty() method that could only be used on DOM objects." - [MDN](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/defineProperty#Internet_Explorer_8_specific_notes)

Currently this polyfill throws in IE8, but wrapping `Object.defineProperty` with a try catch fixes that.
