### PR TITLE
Array#find and Array#findIndex no longer skip holes

### DIFF
--- a/index.js
+++ b/index.js
@@ -13,10 +13,8 @@
     }
     var thisArg = arguments[1];
     for (var i = 0, value; i < length; i++) {
-      if (i in list) {
-        value = list[i];
-        if (predicate.call(thisArg, value, i, list)) return value;
-      }
+      value = list[i];
+      if (predicate.call(thisArg, value, i, list)) return value;
     }
     return undefined;
   };

--- a/tests/test.js
+++ b/tests/test.js
@@ -56,14 +56,15 @@ var runTests = function () {
         });
 
         it('should work with a sparse array', function() {
-          var obj = [1,,undefined];
+          var obj = [1, , undefined];
+          expect(1 in obj).to.equal(false);
           var seen = [];
-          var found = Array.prototype.find.call(obj, function(item, idx) {
+          var found = obj.find(function(item, idx) {
             seen.push([idx, item]);
             return false;
           });
           expect(found).to.equal(undefined);
-          expect(seen).to.eql([[0,1],[2,undefined]]);
+          expect(seen).to.eql([[0, 1], [1, undefined], [2, undefined]]);
         });
 
         it('should work with a sparse array-like object', function() {
@@ -74,10 +75,10 @@ var runTests = function () {
             return false;
           });
           expect(found).to.equal(undefined);
-          expect(seen).to.eql([[0,1],[2,undefined]]);
+          expect(seen).to.eql([[0, 1], [1, undefined], [2, undefined]]);
         });
       });
-  })
+  });
 };
 
 


### PR DESCRIPTION
Per https://bugs.ecmascript.org/show_bug.cgi?id=3107.

Also shipped in https://github.com/paulmillr/es6-shim/issues/280
