### PR TITLE
Fix the browserify example for Linux.

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Browser:
 
 ```javascript
 // component(1)
-require('Array.prototype.find');
+require('array.prototype.find');
 ```
 
 Code example:


### PR DESCRIPTION
Fix for case sensitive file systems. The package name has to match the case of the file in Linux for example.
