### PR TITLE
Change .apply() function applying to .call() calling

### DIFF
--- a/index.js
+++ b/index.js
@@ -11,7 +11,8 @@ var slice = Array.prototype.slice;
 
 var boundFindShim = function find(array, predicate) {
 	ES.RequireObjectCoercible(array);
-	return implementation.apply(array, predicate);
+	var args = Array.prototype.slice.call(arguments, 1);
+	return implementation.apply(array, args);
 };
 
 define(boundFindShim, {

--- a/tests/test.js
+++ b/tests/test.js
@@ -108,3 +108,21 @@ describe('shim', function() {
 		delete Object.prototype[1];
 	});
 });
+
+describe('single function', function() {
+	var findAsFunction = function(func) {
+		var args = Array.prototype.slice.call(arguments);
+		args.unshift(this);
+		return find.apply(undefined, args);
+	}
+
+	describe('clean Object.prototype', function() {
+		runTests(findAsFunction);
+	});
+
+	describe('polluted Object.prototype', function() {
+		Object.prototype[1] = 42;
+		runTests(findAsFunction);
+		delete Object.prototype[1];
+	});
+});


### PR DESCRIPTION
Fix #20 
Are any objections against using `.call()` instead of `.apply()`?
